### PR TITLE
Add option to dump scenes at the origin (0, 0, 0)

### DIFF
--- a/wsocktest/addons/scene_debugger/scene_debugger.tscn
+++ b/wsocktest/addons/scene_debugger/scene_debugger.tscn
@@ -104,6 +104,12 @@ margin_bottom = 576.0
 disabled = true
 text = "Dump ALL Nodes Into Active Scene"
 
+[node name="ForceOrigin" type="CheckBox" parent="VBoxContainer/TabContainer/Scenes"]
+margin_right = 24.0
+margin_bottom = 24.0
+pressed = true
+text = "Make Scenes Be at Origin"
+
 [node name="Events" type="VBoxContainer" parent="VBoxContainer/TabContainer"]
 visible = false
 anchor_right = 1.0


### PR DESCRIPTION
This adds a toggle to the SceneDebugger to make dumped scenes be at the origin by moving the node dumper (so the scenes themselves aren't affected). Works with multiple scenes at once.